### PR TITLE
Mark ServerlessRequest readable

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,17 +1,21 @@
 'use strict';
 
 const http = require('http');
+const stream = require('stream');
 
 module.exports = class ServerlessRequest extends http.IncomingMessage {
   constructor({ method, url, headers, body, remoteAddress }) {
-    super({
+    const socket = new stream.Readable({ read: Function.prototype });
+
+    Object.assign(socket, {
       encrypted: true,
-      readable: false,
       remoteAddress,
       address: () => ({ port: 443 }),
       end: Function.prototype,
       destroy: Function.prototype
     });
+
+    super(socket);
 
     if (typeof headers['content-length'] === 'undefined') {
       headers['content-length'] = Buffer.byteLength(body);
@@ -29,10 +33,9 @@ module.exports = class ServerlessRequest extends http.IncomingMessage {
       url,
     });
 
-    this._read = () => {
-      this.push(body);
-      this.push(null);
-    };
+    this._read = Function.prototype;
+    this.push(body);
+    this.push(null);
   }
 
 }

--- a/test/spec.js
+++ b/test/spec.js
@@ -62,6 +62,7 @@ describe('spec', () => {
         called = true;
         res.end('');
       });
+      req.resume();
     });
 
     await expect(handler(null)).to.be.fulfilled;
@@ -300,6 +301,10 @@ describe('spec', () => {
     delete requestV2.requestContext;
     delete requestV1.apiGateway;
     delete requestV2.apiGateway;
+    requestV1._readableState.buffer = [];
+    requestV1._readableState.length = 0;
+    requestV2._readableState.buffer = [];
+    requestV2._readableState.length = 0;
 
     expect(JSON.stringify(requestV1)).to.equal(JSON.stringify(requestV2));
   });


### PR DESCRIPTION
## Summary
- make ServerlessRequest use a readable stream and preload body
- adjust spec tests for readable request behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af6eff61f48330ae89c47685dc350d